### PR TITLE
PGBadger incremental reporting and configurable directories for logs and reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 out/*
+logs/*
+reports/*
 *.swp
 .idea
 *.iml

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,11 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    aws-sdk-core (2.0.17)
-      builder (~> 3.0)
+    aws-sdk-core (2.3.2)
       jmespath (~> 1.0)
-      multi_json (~> 1.0)
-      multi_xml (~> 0.5)
-    builder (3.2.2)
-    jmespath (1.0.2)
-      multi_json (~> 1.0)
-    multi_json (1.10.1)
-    multi_xml (0.5.5)
+    jmespath (1.2.4)
+      json_pure (>= 1.8.1)
+    json_pure (1.8.3)
     ox (2.1.6)
 
 PLATFORMS
@@ -19,3 +14,6 @@ PLATFORMS
 DEPENDENCIES
   aws-sdk-core
   ox
+
+BUNDLED WITH
+   1.12.1

--- a/rds-pgbadger.rb
+++ b/rds-pgbadger.rb
@@ -7,6 +7,12 @@ require 'ox'
 require 'aws-sdk-core'
 
 options = {}
+options[:logs_directory] = "logs"
+options[:reports_directory] = "reports"
+options[:parallel] = true
+#options[:incremental] = false
+options[:pgbadger] = 'pgbadger'
+options[:pgbadger_args] = ''
 OptionParser.new do |opts|
     opts.banner = 'Usage: rds-pgbadger.rb [options]'
 
@@ -14,11 +20,15 @@ OptionParser.new do |opts|
     opts.on('-i', '--instance-id NAME', 'RDS instance identifier') { |v| options[:instance_id] = v }
     opts.on('-r', '--region REGION', 'RDS instance region') { |v| options[:region] = v }
     opts.on('-d', '--date DATE', 'Filter logs to given date in format YYYY-MM-DD.') { |v| options[:date] = v }
-    opts.on('-p', '--parallel', 'Run in parallel') { |v| options[:parallel] = true }
-
+    opts.on('--logs-directory DIRECTORY', "Download logs to this directory (Default: ./#{options[:logs_directory]})") { |v| options[:logs_directory] = v }
+    opts.on('--reports-directory DIRECTORY', "Generate PGBadger report html in this directory (Default: ./#{options[:reports_directory]})") { |v| options[:reports_directory] = v }
+    opts.on('-p', '--[no-]parallel', 'Run PGBadger in parallel mode. (Default: true)') { |v| options[:parallel] = v }
+    #opts.on('-I', '--[no-]incremental', 'Run PGBadger in incremental mode. (Default: true if instance''s report .html file exists.)') { |v| options[:incremental] = v }
+    opts.on('--view', 'View results in your browser? Useful when running from a workstation. (Default: false)') { |v| options[:view] = true }
+    opts.on('--pgbadger /PATH/TO/PGBADGER', 'Path to PGBadger executable') { |v| options[:pgbadger] = v }
+    opts.on('--pgbadger-args a,b,c', 'Arguments for PGBadger') { |v| options[:pgbadger_args] = v }
 end.parse!
 
-raise OptionParser::MissingArgument.new(:env) if options[:env].nil?
 raise OptionParser::MissingArgument.new(:instance_id) if options[:instance_id].nil?
 raise OptionParser::MissingArgument.new(:region) if options[:region].nil?
 
@@ -37,46 +47,64 @@ def self.processor_count
   end
 end
 
-creds = YAML.load(File.read(File.expand_path('~/.fog')))
+creds = {}
+access_key_id = nil
+secret_access_key = nil
+fog_file = File.expand_path('~/.fog')
+if File.exist?(fog_file)
+  creds = YAML.load(File.read(fog_file))
+  access_key_id = creds[options[:env]]['aws_access_key_id']
+  secret_access_key = creds[options[:env]]['aws_secret_access_key']
+end
 
 puts "Instantiating RDS client for #{options[:env]} environment."
 rds = Aws::RDS::Client.new(
   region: options[:region],
-  access_key_id: creds[options[:env]]['aws_access_key_id'],
-  secret_access_key: creds[options[:env]]['aws_secret_access_key']
+  access_key_id: access_key_id,
+  secret_access_key: secret_access_key,
 )
 log_files = rds.describe_db_log_files(db_instance_identifier: options[:instance_id], filename_contains: "postgresql.log.#{options[:date]}")[:describe_db_log_files].map(&:log_file_name)
 
-dir_name = "#{options[:instance_id]}-#{Time.now.to_i}"
+dir_name = "#{options[:instance_id]}"
+log_dir = "#{options[:logs_directory]}/#{dir_name}"
+report_dir = "#{options[:reports_directory]}/#{dir_name}"
+report_file = "#{report_dir}/index.html"
 
-FileUtils.mkdir_p("out/#{dir_name}/error")
+FileUtils.mkdir_p("#{log_dir}/error")
 log_files.each do |log_file|
   puts "Downloading log file: #{log_file}"
-  open("out/#{dir_name}/#{log_file}", 'w') do |f|
+  open("#{log_dir}/#{log_file}", 'w') do |f|
     rds.download_db_log_file_portion(db_instance_identifier: options[:instance_id], log_file_name: log_file).each do |r|
       print '.'
       f.puts r[:log_file_data]
     end
     puts '.'
   end
-  puts "Saved log to out/#{dir_name}/#{log_file}."
+  puts "Saved log to #{log_dir}/#{log_file}."
 end
 
-parallel = ''
 if options[:parallel]
   parallel = "-j #{processor_count}"
 end
 
-puts 'Generating PG Badger report.'
-`pgbadger --prefix "%t:%r:%u@%d:[%p]:" #{parallel} --outfile out/#{dir_name}/#{dir_name}.html out/#{dir_name}/error/*.log.*`
+if File.exist?(report_file)
+  puts "Running PGBadger in incremental mode"
+  incremental = "--incremental"
+end
 
-case RbConfig::CONFIG['host_os']
-  when /darwin|mac os/i
-    puts "Opening report out/#{dir_name}/#{dir_name}.html."
-    `open out/#{dir_name}/#{dir_name}.html`
-  when /linux/i
-    puts "Opening report out/#{dir_name}/#{dir_name}.html."
-    `xdg-open out/#{dir_name}/#{dir_name}.html`
-  else
-    puts `Generated: out/#{dir_name}/#{dir_name}.html`
+puts 'Generating PG Badger report.'
+FileUtils.mkdir_p("#{report_dir}")
+`#{options[:pgbadger]} --prefix "%t:%r:%u@%d:[%p]:" #{parallel} #{incremental} --outfile #{report_file} #{log_dir}/error/*.log.*`
+
+if options[:view]
+  case RbConfig::CONFIG['host_os']
+    when /darwin|mac os/i
+      puts "Opening report out/#{dir_name}/#{dir_name}.html."
+      `open out/#{dir_name}/#{dir_name}.html`
+    when /linux/i
+      puts "Opening report out/#{dir_name}/#{dir_name}.html."
+      `xdg-open out/#{dir_name}/#{dir_name}.html`
+    else
+      puts `Generated: out/#{dir_name}/#{dir_name}.html`
+  end
 end

--- a/rds-pgbadger.rb
+++ b/rds-pgbadger.rb
@@ -10,7 +10,6 @@ options = {}
 options[:logs_directory] = "logs"
 options[:reports_directory] = "reports"
 options[:parallel] = true
-#options[:incremental] = false
 options[:pgbadger] = 'pgbadger'
 options[:pgbadger_args] = ''
 OptionParser.new do |opts|
@@ -23,7 +22,6 @@ OptionParser.new do |opts|
     opts.on('--logs-directory DIRECTORY', "Download logs to this directory (Default: ./#{options[:logs_directory]})") { |v| options[:logs_directory] = v }
     opts.on('--reports-directory DIRECTORY', "Generate PGBadger report html in this directory (Default: ./#{options[:reports_directory]})") { |v| options[:reports_directory] = v }
     opts.on('-p', '--[no-]parallel', 'Run PGBadger in parallel mode. (Default: true)') { |v| options[:parallel] = v }
-    #opts.on('-I', '--[no-]incremental', 'Run PGBadger in incremental mode. (Default: true if instance''s report .html file exists.)') { |v| options[:incremental] = v }
     opts.on('--view', 'View results in your browser? Useful when running from a workstation. (Default: false)') { |v| options[:view] = true }
     opts.on('--pgbadger /PATH/TO/PGBADGER', 'Path to PGBadger executable') { |v| options[:pgbadger] = v }
     opts.on('--pgbadger-args a,b,c', 'Arguments for PGBadger') { |v| options[:pgbadger_args] = v }


### PR DESCRIPTION
## SUMMARY OF CHANGES
- Update to newer version of aws-sdk-core 2.0.17 -> 2.3.2
- Runs PGBadger in incremental mode if the report file exists.
- New arguments:
  - `--logs-directory`: the path where to download RDS logs
  - `--reports-directory`: the path where to store the PGBadger reports
  - `--pgbadger`: the path to the PGBadger executable
  - `--pgbadger-args`: arguments to pass to the PGBadger executable
  - `--view`: open a browser to view the report results
